### PR TITLE
fix: can swap if the inventory type is main

### DIFF
--- a/inventory_slot.gd
+++ b/inventory_slot.gd
@@ -20,6 +20,11 @@ func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
 				return true
 			else:
 				# Swap two items
+				var parentSource: InventorySlot = get_child(0).get_parent()
+				var parentTarget: InventorySlot = data.get_parent()
+				
+				if parentSource.type == parentTarget.type: return true
+				
 				return get_child(0).type == data.type
 		else:
 			return data.type == type


### PR DESCRIPTION
It is now possible to exchange any type of item if the inventory is of type main
https://github.com/ShatReal/drag-drop-inventory/assets/55464917/43a6c835-d9da-4880-9771-725054733577

