### PR TITLE
Centers cursor on preview + Bump to 4.2

### DIFF
--- a/inventory_item.gd
+++ b/inventory_item.gd
@@ -24,11 +24,16 @@ func _get_drag_data(_at_position: Vector2) -> Variant:
 	return self
 
 
-func make_drag_preview() -> TextureRect:
+func make_drag_preview() -> Control:
 	var t := TextureRect.new()
 	t.texture = texture
 	t.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 	t.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	t.custom_minimum_size = size
 	t.modulate.a = 0.5
-	return t
+	t.position = Vector2(-size/2)
+
+	var c := Control.new()
+	c.add_child(t)
+
+	return c

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="DragDrop Inventory"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.1", "GL Compatibility")
+config/features=PackedStringArray("4.2", "GL Compatibility")
 config/icon="res://icon.png"
 
 [rendering]


### PR DESCRIPTION
Hello, I'm an experienced dev and a total noob to Godot. 

I like looking at live examples to get an idea of how stuff works, and your project is perfect for this. Thank you for your work :)

I found a perfect first issue for me: preview's position was a bit off (top-left corner instead of center)

Before
![image](https://github.com/ShatReal/drag-drop-inventory/assets/6434104/00267724-b55c-46ab-b8d8-44d91d560f15)

After
![image](https://github.com/ShatReal/drag-drop-inventory/assets/6434104/dc33abec-43e6-4bc0-85ff-e161540a032e)


Source used (I modified the hardcoded size to `-size/2`): https://www.reddit.com/r/godot/comments/wkjymo/set_drag_preview_is_not_setting_it_relative_to/

I tried at first without the extra `Control` but it does not work. Maybe someone with experience might have a better idea :man_shrugging: 
